### PR TITLE
Add digital inputs diagnostics modal to hamburger menu

### DIFF
--- a/tusas-hgu-modern/Frontend/src/components/DigitalInputsModal/DigitalInputsModal.css
+++ b/tusas-hgu-modern/Frontend/src/components/DigitalInputsModal/DigitalInputsModal.css
@@ -1,0 +1,441 @@
+.digital-inputs-modal {
+  width: min(1100px, 92vw);
+  height: min(760px, 92vh);
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(160deg,
+      rgba(14, 20, 26, 0.95),
+      rgba(8, 12, 18, 0.92));
+  border: 1px solid rgba(0, 153, 255, 0.28);
+  box-shadow:
+    0 28px 60px rgba(0, 0, 0, 0.55),
+    0 0 45px rgba(0, 153, 255, 0.18);
+}
+
+.digital-inputs-header {
+  gap: 8px;
+  background: linear-gradient(135deg,
+      rgba(20, 28, 36, 0.9),
+      rgba(10, 18, 26, 0.75));
+}
+
+.digital-inputs-header h3 {
+  font-size: 20px;
+  letter-spacing: 0.4px;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.digital-inputs-subtitle {
+  margin-top: 4px;
+  font-size: 13px;
+  color: rgba(168, 178, 192, 0.85);
+}
+
+.digital-inputs-body {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  overflow-y: auto;
+  background:
+    radial-gradient(circle at top left, rgba(0, 153, 255, 0.08), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(0, 255, 136, 0.08), transparent 40%),
+    linear-gradient(160deg, rgba(10, 16, 22, 0.85), rgba(6, 10, 15, 0.95));
+}
+
+.digital-groups-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.digital-group-card {
+  background: rgba(18, 26, 34, 0.9);
+  border: 1px solid rgba(96, 160, 255, 0.18);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 153, 255, 0.08),
+    0 18px 30px rgba(0, 0, 0, 0.28);
+  overflow: hidden;
+}
+
+.digital-group-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(0, 153, 255, 0.15), transparent 55%);
+  pointer-events: none;
+}
+
+.digital-group-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  position: relative;
+  z-index: 1;
+}
+
+.digital-group-icon {
+  font-size: 26px;
+  filter: drop-shadow(0 0 8px rgba(0, 153, 255, 0.35));
+}
+
+.digital-group-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.digital-group-description {
+  font-size: 13px;
+  color: rgba(168, 178, 192, 0.82);
+  margin-top: 2px;
+}
+
+.digital-input-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.digital-input-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(96, 160, 255, 0.15);
+  background: linear-gradient(135deg, rgba(16, 22, 30, 0.9), rgba(10, 14, 20, 0.85));
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 153, 255, 0.05),
+    0 12px 22px rgba(0, 0, 0, 0.35);
+}
+
+.digital-input-item.is-active.severity-success {
+  border-color: rgba(0, 255, 136, 0.35);
+  background: linear-gradient(135deg, rgba(10, 32, 24, 0.92), rgba(6, 22, 18, 0.8));
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 255, 136, 0.12),
+    0 14px 26px rgba(0, 255, 136, 0.12);
+}
+
+.digital-input-item.is-active.severity-critical {
+  border-color: rgba(220, 20, 60, 0.42);
+  background: linear-gradient(135deg, rgba(32, 14, 18, 0.92), rgba(24, 8, 12, 0.82));
+  box-shadow:
+    inset 0 0 0 1px rgba(220, 20, 60, 0.18),
+    0 14px 28px rgba(220, 20, 60, 0.18);
+}
+
+.digital-input-item.is-active.severity-warning {
+  border-color: rgba(255, 165, 0, 0.32);
+  background: linear-gradient(135deg, rgba(32, 24, 10, 0.9), rgba(26, 18, 6, 0.82));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 165, 0, 0.14),
+    0 14px 26px rgba(255, 165, 0, 0.15);
+}
+
+.digital-input-item.is-active.severity-info {
+  border-color: rgba(0, 153, 255, 0.32);
+  background: linear-gradient(135deg, rgba(12, 26, 36, 0.92), rgba(8, 18, 28, 0.84));
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 153, 255, 0.12),
+    0 14px 24px rgba(0, 153, 255, 0.15);
+}
+
+.digital-input-info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex: 1;
+}
+
+.digital-input-icon {
+  font-size: 22px;
+  filter: drop-shadow(0 0 6px rgba(0, 153, 255, 0.25));
+}
+
+.digital-input-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.digital-input-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(235, 240, 248, 0.92);
+}
+
+.digital-input-desc {
+  font-size: 12px;
+  color: rgba(168, 178, 192, 0.78);
+  letter-spacing: 0.2px;
+}
+
+.digital-input-state {
+  min-width: 124px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 160, 255, 0.2);
+  background: rgba(14, 20, 28, 0.9);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: rgba(176, 188, 204, 0.9);
+  text-transform: uppercase;
+}
+
+.digital-input-state.is-active.severity-success {
+  border-color: rgba(0, 255, 136, 0.5);
+  background: rgba(0, 255, 136, 0.12);
+  color: rgba(160, 255, 216, 0.95);
+}
+
+.digital-input-state.is-active.severity-critical {
+  border-color: rgba(220, 20, 60, 0.5);
+  background: rgba(220, 20, 60, 0.12);
+  color: rgba(255, 186, 194, 0.95);
+}
+
+.digital-input-state.is-active.severity-warning {
+  border-color: rgba(255, 165, 0, 0.45);
+  background: rgba(255, 165, 0, 0.12);
+  color: rgba(255, 220, 170, 0.95);
+}
+
+.digital-input-state.is-active.severity-info {
+  border-color: rgba(0, 153, 255, 0.45);
+  background: rgba(0, 153, 255, 0.12);
+  color: rgba(180, 220, 255, 0.95);
+}
+
+.digital-input-state.is-inactive {
+  border-style: dashed;
+  color: rgba(150, 160, 176, 0.76);
+}
+
+.digital-input-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(150, 160, 176, 0.45);
+  box-shadow: 0 0 6px rgba(150, 160, 176, 0.35);
+}
+
+.digital-input-state.is-active.severity-success .digital-input-dot {
+  background: var(--color-running, #32cd32);
+  box-shadow: 0 0 10px rgba(0, 255, 136, 0.55);
+}
+
+.digital-input-state.is-active.severity-critical .digital-input-dot {
+  background: var(--color-error, #dc143c);
+  box-shadow: 0 0 10px rgba(220, 20, 60, 0.55);
+}
+
+.digital-input-state.is-active.severity-warning .digital-input-dot {
+  background: var(--color-warning, #ffa500);
+  box-shadow: 0 0 10px rgba(255, 165, 0, 0.55);
+}
+
+.digital-input-state.is-active.severity-info .digital-input-dot {
+  background: var(--color-ready, #1e90ff);
+  box-shadow: 0 0 10px rgba(30, 144, 255, 0.55);
+}
+
+.digital-motor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.digital-section-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.digital-section-icon {
+  font-size: 28px;
+  filter: drop-shadow(0 0 8px rgba(0, 153, 255, 0.3));
+}
+
+.digital-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(235, 240, 248, 0.9);
+}
+
+.digital-section-description {
+  font-size: 13px;
+  color: rgba(168, 178, 192, 0.78);
+  margin-top: 2px;
+}
+
+.digital-motor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.digital-motor-card {
+  background: rgba(16, 24, 32, 0.92);
+  border: 1px solid rgba(96, 160, 255, 0.18);
+  border-radius: 14px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 153, 255, 0.08),
+    0 16px 26px rgba(0, 0, 0, 0.28);
+}
+
+.digital-motor-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.digital-motor-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.digital-motor-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: rgba(235, 240, 248, 0.92);
+}
+
+.digital-motor-status {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  font-weight: 700;
+  border: 1px solid rgba(96, 160, 255, 0.22);
+  background: rgba(8, 18, 26, 0.85);
+  color: rgba(176, 188, 204, 0.9);
+}
+
+.digital-motor-status.is-enabled {
+  border-color: rgba(0, 255, 136, 0.42);
+  background: rgba(0, 255, 136, 0.12);
+  color: rgba(170, 255, 214, 0.95);
+}
+
+.digital-motor-status.is-disabled {
+  border-style: dashed;
+  color: rgba(148, 160, 176, 0.78);
+}
+
+.digital-motor-subtitle {
+  font-size: 12px;
+  color: rgba(168, 178, 192, 0.72);
+  letter-spacing: 0.2px;
+}
+
+.digital-motor-status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.digital-motor-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(96, 160, 255, 0.18);
+  background: linear-gradient(135deg, rgba(18, 26, 34, 0.92), rgba(10, 16, 24, 0.88));
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 153, 255, 0.08),
+    0 12px 18px rgba(0, 0, 0, 0.28);
+}
+
+.digital-motor-chip.is-active.severity-success {
+  border-color: rgba(0, 255, 136, 0.35);
+  background: linear-gradient(135deg, rgba(10, 30, 22, 0.9), rgba(8, 22, 18, 0.82));
+}
+
+.digital-motor-chip.is-active.severity-critical {
+  border-color: rgba(220, 20, 60, 0.38);
+  background: linear-gradient(135deg, rgba(32, 14, 18, 0.9), rgba(22, 10, 14, 0.82));
+}
+
+.digital-motor-chip.is-active.severity-warning {
+  border-color: rgba(255, 165, 0, 0.34);
+  background: linear-gradient(135deg, rgba(32, 24, 10, 0.9), rgba(24, 16, 8, 0.82));
+}
+
+.digital-motor-chip.is-active.severity-info {
+  border-color: rgba(0, 153, 255, 0.34);
+  background: linear-gradient(135deg, rgba(12, 24, 34, 0.9), rgba(8, 18, 28, 0.82));
+}
+
+.digital-motor-chip.is-inactive {
+  border-style: dashed;
+  color: rgba(150, 160, 176, 0.76);
+}
+
+.digital-motor-chip-icon {
+  font-size: 18px;
+}
+
+.digital-motor-chip-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.digital-motor-chip-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(228, 234, 244, 0.9);
+}
+
+.digital-motor-chip-state {
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  color: rgba(176, 188, 204, 0.85);
+  text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+  .digital-inputs-modal {
+    width: 95vw;
+    height: 92vh;
+  }
+
+  .digital-inputs-body {
+    padding: 18px;
+    gap: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .digital-inputs-body {
+    padding: 16px;
+  }
+
+  .digital-motor-status-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}

--- a/tusas-hgu-modern/Frontend/src/components/DigitalInputsModal/index.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/DigitalInputsModal/index.tsx
@@ -1,0 +1,429 @@
+import React, { useEffect, useMemo } from 'react';
+import { useOpcStore } from '../../store/opcStore';
+import './DigitalInputsModal.css';
+
+type Severity = 'success' | 'critical' | 'warning' | 'info';
+
+type MotorBooleanKey =
+  | 'startAck'
+  | 'stopAck'
+  | 'resetAck'
+  | 'manualValve'
+  | 'lineFilter'
+  | 'suctionFilter';
+
+interface DigitalInputItem {
+  id: string;
+  label: string;
+  value: boolean;
+  description: string;
+  icon: string;
+  severity?: Severity;
+  activeLabel?: string;
+  inactiveLabel?: string;
+}
+
+interface DigitalInputGroup {
+  id: string;
+  title: string;
+  icon: string;
+  description: string;
+  items: DigitalInputItem[];
+}
+
+interface DigitalInputsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const motorStatusConfigs: Array<{
+  key: MotorBooleanKey;
+  label: string;
+  icon: string;
+  severity: Severity;
+  activeLabel?: string;
+  inactiveLabel?: string;
+}> = [
+  {
+    key: 'startAck',
+    label: 'Başlatma Onayı',
+    icon: '✅',
+    severity: 'success',
+    activeLabel: 'Onaylandı',
+    inactiveLabel: 'Beklemede',
+  },
+  {
+    key: 'stopAck',
+    label: 'Durdurma Onayı',
+    icon: '⏹️',
+    severity: 'info',
+    activeLabel: 'Onaylandı',
+    inactiveLabel: 'Beklemede',
+  },
+  {
+    key: 'resetAck',
+    label: 'Reset Onayı',
+    icon: '♻️',
+    severity: 'info',
+    activeLabel: 'Hazır',
+    inactiveLabel: 'Pasif',
+  },
+  {
+    key: 'manualValve',
+    label: 'Manuel Vana Açık',
+    icon: '🧰',
+    severity: 'warning',
+    activeLabel: 'Açık',
+    inactiveLabel: 'Kapalı',
+  },
+  {
+    key: 'lineFilter',
+    label: 'Hat Filtresi Alarmı',
+    icon: '🧼',
+    severity: 'warning',
+    activeLabel: 'Aktif',
+    inactiveLabel: 'Normal',
+  },
+  {
+    key: 'suctionFilter',
+    label: 'Emme Filtresi Alarmı',
+    icon: '🌀',
+    severity: 'warning',
+    activeLabel: 'Aktif',
+    inactiveLabel: 'Normal',
+  },
+];
+
+const DigitalInputsModal: React.FC<DigitalInputsModalProps> = ({ isOpen, onClose }) => {
+  const system = useOpcStore((state) => state.system);
+  const motors = useOpcStore((state) => state.motors);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const digitalGroups = useMemo<DigitalInputGroup[]>(() => [
+    {
+      id: 'safety',
+      title: 'Güvenlik & Acil Durum',
+      icon: '🛡️',
+      description: 'Operatör panosu ve kritik emniyet girişleri',
+      items: [
+        {
+          id: 'emergency-stop',
+          label: 'Acil Stop Butonu',
+          icon: '🆘',
+          value: system.emergencyStop,
+          description: 'Panel üzerindeki acil durdurma hattının durumu',
+          severity: 'critical',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Serbest',
+        },
+        {
+          id: 'system-enable',
+          label: 'Sistem Enable Girişi',
+          icon: '🟢',
+          value: system.systemEnable,
+          description: 'Hidrolik ünitenin çalışmasına izin veren dijital giriş',
+          severity: 'success',
+          activeLabel: 'Etkin',
+          inactiveLabel: 'Pasif',
+        },
+        {
+          id: 'system-error',
+          label: 'Sistem Hata Kontağı',
+          icon: '🚨',
+          value: system.systemErrorActive,
+          description: 'PLC tarafından algılanan genel sistem hatası',
+          severity: 'critical',
+          activeLabel: 'Hata',
+          inactiveLabel: 'Normal',
+        },
+        {
+          id: 'safety-error',
+          label: 'Kritik Emniyet Hatası',
+          icon: '⚠️',
+          value: system.criticalSafetyError,
+          description: 'Emniyet rölelerinden gelen kritik alarm hattı',
+          severity: 'critical',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Normal',
+        },
+      ],
+    },
+    {
+      id: 'process',
+      title: 'Proses & Koruma',
+      icon: '🧭',
+      description: 'Basınç emniyeti ve tank seviyeleri için girişler',
+      items: [
+        {
+          id: 'pressure-safety-enable',
+          label: 'Basınç Emniyet Valf Enable',
+          icon: '🧯',
+          value: system.pressureSafetyValvesEnable,
+          description: 'Emniyet valflerinin devreye alınma bilgisi',
+          severity: 'success',
+          activeLabel: 'Devrede',
+          inactiveLabel: 'Devre Dışı',
+        },
+        {
+          id: 'pressure-safety-comm',
+          label: 'Emniyet Valfi Haberleşmesi',
+          icon: '📡',
+          value: system.pressureSafetyValvesCommOk,
+          description: 'Emniyet valf modülünden iletişim geri bildirimi',
+          severity: 'info',
+          activeLabel: 'Sağlam',
+          inactiveLabel: 'Kesildi',
+        },
+        {
+          id: 'tank-min',
+          label: 'Tank Seviye Min',
+          icon: '📉',
+          value: system.tankMinLevel,
+          description: 'Minimum yağ seviyesi şamandıra girişi',
+          severity: 'warning',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Normal',
+        },
+        {
+          id: 'tank-max',
+          label: 'Tank Seviye Max',
+          icon: '📈',
+          value: system.tankMaxLevel,
+          description: 'Maksimum yağ seviyesi şamandıra girişi',
+          severity: 'warning',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Normal',
+        },
+        {
+          id: 'chiller-flow',
+          label: 'Soğutucu Su Akışı',
+          icon: '💧',
+          value: system.chillerWaterFlowStatus,
+          description: 'Soğutucu su hattından gelen akış bilgisi',
+          severity: 'info',
+          activeLabel: 'Akış Var',
+          inactiveLabel: 'Yetersiz',
+        },
+      ],
+    },
+    {
+      id: 'communication',
+      title: 'Haberleşme & Ağ',
+      icon: '🛰️',
+      description: 'CAN hatları ve sistem haberleşme geri bildirimleri',
+      items: [
+        {
+          id: 'can-active',
+          label: 'CAN Haberleşmesi Aktif',
+          icon: '🔄',
+          value: system.canCommunicationActive,
+          description: 'CAN bus hattının genel çalışma durumu',
+          severity: 'success',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Pasif',
+        },
+        {
+          id: 'can-tcp',
+          label: 'CAN TCP Bağlantısı',
+          icon: '🌐',
+          value: system.canTcpConnected,
+          description: 'SCADA ile CAN gateway arasındaki bağlantı bilgisi',
+          severity: 'success',
+          activeLabel: 'Bağlı',
+          inactiveLabel: 'Kopuk',
+        },
+        {
+          id: 'can-error',
+          label: 'CAN Sistem Hatası',
+          icon: '🛑',
+          value: system.canSystemError,
+          description: 'CAN haberleşmesinden gelen genel hata kontağı',
+          severity: 'critical',
+          activeLabel: 'Hata',
+          inactiveLabel: 'Normal',
+        },
+        {
+          id: 'any-motor-error',
+          label: 'Motor Hata Takibi',
+          icon: '🧱',
+          value: system.anyMotorError,
+          description: 'Motorlardan herhangi birinde hata bilgisi',
+          severity: 'warning',
+          activeLabel: 'Aktif',
+          inactiveLabel: 'Normal',
+        },
+      ],
+    },
+  ], [
+    system.emergencyStop,
+    system.systemEnable,
+    system.systemErrorActive,
+    system.criticalSafetyError,
+    system.pressureSafetyValvesEnable,
+    system.pressureSafetyValvesCommOk,
+    system.tankMinLevel,
+    system.tankMaxLevel,
+    system.chillerWaterFlowStatus,
+    system.canCommunicationActive,
+    system.canTcpConnected,
+    system.canSystemError,
+    system.anyMotorError,
+  ]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay digital-inputs-overlay" onClick={onClose}>
+      <div
+        className="modal-content digital-inputs-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="digital-inputs-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header digital-inputs-header">
+          <div>
+            <h3 id="digital-inputs-title">Dijital Girişler İzleme</h3>
+            <p className="digital-inputs-subtitle">
+              Kritik sensör ve emniyet girişlerinin anlık durumları
+            </p>
+          </div>
+          <button className="modal-close" onClick={onClose} aria-label="Kapat">
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body digital-inputs-body">
+          <div className="digital-groups-grid">
+            {digitalGroups.map((group) => (
+              <section key={group.id} className="digital-group-card">
+                <header className="digital-group-header">
+                  <span className="digital-group-icon" aria-hidden="true">
+                    {group.icon}
+                  </span>
+                  <div>
+                    <h4 className="digital-group-title">{group.title}</h4>
+                    <p className="digital-group-description">{group.description}</p>
+                  </div>
+                </header>
+
+                <div className="digital-input-list">
+                  {group.items.map((item) => {
+                    const severity = item.severity ?? 'info';
+                    const itemClassName = `digital-input-item ${
+                      item.value ? 'is-active' : 'is-inactive'
+                    } severity-${severity}`;
+                    const stateClassName = `digital-input-state ${
+                      item.value ? 'is-active' : 'is-inactive'
+                    } severity-${severity}`;
+
+                    return (
+                      <article key={item.id} className={itemClassName}>
+                        <div className="digital-input-info">
+                          <span className="digital-input-icon" aria-hidden="true">
+                            {item.icon}
+                          </span>
+                          <div className="digital-input-text">
+                            <span className="digital-input-name">{item.label}</span>
+                            <span className="digital-input-desc">{item.description}</span>
+                          </div>
+                        </div>
+                        <div className={stateClassName}>
+                          <span className="digital-input-dot" aria-hidden="true" />
+                          <span className="digital-input-state-label">
+                            {item.value
+                              ? item.activeLabel ?? 'Aktif'
+                              : item.inactiveLabel ?? 'Pasif'}
+                          </span>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <section className="digital-motor-section">
+            <header className="digital-section-header">
+              <span className="digital-section-icon" aria-hidden="true">
+                ⚙️
+              </span>
+              <div>
+                <h4 className="digital-section-title">Motor Dijital Girişleri</h4>
+                <p className="digital-section-description">
+                  Her motor için enable, onay ve filtre sensör bilgileri
+                </p>
+              </div>
+            </header>
+
+            <div className="digital-motor-grid">
+              {Object.entries(motors).map(([motorId, motor]) => (
+                <article key={motorId} className="digital-motor-card">
+                  <header className="digital-motor-header">
+                    <div className="digital-motor-title">
+                      <span className="digital-motor-name">Motor {motorId}</span>
+                      <span
+                        className={`digital-motor-status ${
+                          motor.enabled ? 'is-enabled' : 'is-disabled'
+                        }`}
+                      >
+                        {motor.enabled ? 'ÇALIŞMA İZNİ' : 'PASİF'}
+                      </span>
+                    </div>
+                    <span className="digital-motor-subtitle">
+                      {motor.manualValve ? 'Manuel mod aktif' : 'Otomatik kontrol'}
+                    </span>
+                  </header>
+
+                  <div className="digital-motor-status-grid">
+                    {motorStatusConfigs.map((config) => {
+                      const value = motor[config.key];
+                      const chipClass = `digital-motor-chip ${
+                        value ? 'is-active' : 'is-inactive'
+                      } severity-${config.severity}`;
+
+                      return (
+                        <div key={config.key} className={chipClass}>
+                          <span className="digital-motor-chip-icon" aria-hidden="true">
+                            {config.icon}
+                          </span>
+                          <div className="digital-motor-chip-text">
+                            <span className="digital-motor-chip-label">{config.label}</span>
+                            <span className="digital-motor-chip-state">
+                              {value
+                                ? config.activeLabel ?? 'Aktif'
+                                : config.inactiveLabel ?? 'Pasif'}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DigitalInputsModal;

--- a/tusas-hgu-modern/Frontend/src/components/HamburgerMenu/index.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/HamburgerMenu/index.tsx
@@ -5,6 +5,7 @@ import PressureCalibration from '../PressureCalibration';
 import FlowCalibration from '../FlowCalibration';
 import TemperatureCalibration from '../TemperatureCalibration';
 import OpcDataMonitor from '../OpcDataMonitor';
+import DigitalInputsModal from '../DigitalInputsModal';
 import './HamburgerMenu.css';
 
 interface HamburgerMenuProps {
@@ -29,6 +30,7 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onToggle, onClose
   const [showFlowCalibration, setShowFlowCalibration] = useState(false);
   const [showTemperatureCalibration, setShowTemperatureCalibration] = useState(false);
   const [showOpcDataMonitor, setShowOpcDataMonitor] = useState(false);
+  const [showDigitalInputs, setShowDigitalInputs] = useState(false);
   const { logout, user } = useAuth();
 
   // Handle logout with safety warning modal
@@ -111,12 +113,20 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onToggle, onClose
       ]
     },
     {
+      id: 'diagnostics',
+      label: 'Diagnostik',
+      icon: '🩺',
+      items: [
+        { id: 'system-diagnostics', label: 'Sistem Tanılama', icon: '🔍', action: () => console.log('Diagnostics') },
+        { id: 'digital-inputs', label: 'Dijital Girişler', icon: '🧠', action: () => setShowDigitalInputs(true) },
+        { id: 'opc-monitor', label: 'OPC Data Monitor', icon: '📊', action: () => setShowOpcDataMonitor(true) }
+      ]
+    },
+    {
       id: 'maintenance',
       label: 'Maintenance',
       icon: '🔧',
       items: [
-        { id: 'diagnostics', label: 'System Diagnostics', icon: '🔍', action: () => console.log('Diagnostics') },
-        { id: 'opc-monitor', label: 'OPC Data Monitor', icon: '📊', action: () => setShowOpcDataMonitor(true) },
         { id: 'filter-status', label: 'Filter Status', icon: '🔽', action: () => console.log('Filter status') },
         { id: 'scheduled-maint', label: 'Scheduled Tasks', icon: '📅', action: () => console.log('Scheduled') },
         { id: 'logs', label: 'System Logs', icon: '📋', action: () => console.log('Logs') }
@@ -326,6 +336,11 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen, onToggle, onClose
           </div>
         </div>
       )}
+
+      <DigitalInputsModal
+        isOpen={showDigitalInputs}
+        onClose={() => setShowDigitalInputs(false)}
+      />
     </>
   );
 };

--- a/tusas-hgu-modern/Frontend/src/components/PressureCalibration/index.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/PressureCalibration/index.tsx
@@ -39,8 +39,8 @@ const PressureCalibration: React.FC<PressureCalibrationProps> = ({
 }) => {
   // OPC Store state
   const motors = useOpcStore((state) => state.motors);
-  const systemPressure = useOpcStore((state) => state.systemPressure || 0);
-  const systemPressureSetpoint = useOpcStore((state) => state.systemPressureSetpoint || 0);
+  const systemPressure = useOpcStore((state) => state.system.totalPressure || 0);
+  const systemPressureSetpoint = useOpcStore((state) => state.system.pressureSetpoint || 0);
 
   // Loading and modal states
   const [isLoading, setIsLoading] = useState(false);

--- a/tusas-hgu-modern/Frontend/src/services/api.ts
+++ b/tusas-hgu-modern/Frontend/src/services/api.ts
@@ -28,6 +28,14 @@ export interface InfluxMotorSeriesResponse {
   MaxPoints?: number | null;
   MotorSeries: InfluxMotorSeriesPoint[];
   SystemSeries: InfluxSystemTrendPoint[];
+  // Optional camelCase keys for backward compatibility with older API responses
+  success?: boolean;
+  range?: string;
+  motors?: number[];
+  metrics?: string[];
+  maxPoints?: number | null;
+  motorSeries?: InfluxMotorSeriesPoint[];
+  systemSeries?: InfluxSystemTrendPoint[];
 }
 
 // Backend API base URL


### PR DESCRIPTION
## Summary
- add a dedicated "Dijital Girişler" option under the diagnostics section of the hamburger menu
- build a SCADA-themed digital inputs modal that visualizes system and motor-level boolean statuses
- align pressure calibration and InfluxDB typings with the current OPC store data and API casing variants

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d055f2ef6c8322a34a4703fb68e007