### PR TITLE
Refactor InfluxDB monitor into tabbed view with fullscreen charts

### DIFF
--- a/tusas-hgu-modern/Frontend/src/App.tsx
+++ b/tusas-hgu-modern/Frontend/src/App.tsx
@@ -10,7 +10,7 @@ import SystemOverviewPanel from './components/SystemOverviewPanel';
 import TankCoolingPanel from './components/TankCoolingPanel';
 import { LogsPage } from './components/LogsPage';
 import AlarmsPage from './components/AlarmsPage';
-import InfluxDBMonitor from './components/InfluxDBMonitor';
+import InfluxDBMonitor, { InfluxMonitorTab } from './components/InfluxDBMonitor';
 import './styles/industrial-theme.css';
 import './styles/modern-layout.css';
 
@@ -33,6 +33,7 @@ function App() {
   const [selectedMotorId, setSelectedMotorId] = useState<number | null>(null);
   const [selectedSystemPanel, setSelectedSystemPanel] = useState<string | null>(null);
   const [alarms, setAlarms] = useState<Array<{ id: number; message: string; type: string }>>([]);
+  const [influxSubPage, setInfluxSubPage] = useState<InfluxMonitorTab>('summary');
   
   // Use system mode transition hook
   const transitionState = useSystemModeTransition();
@@ -87,6 +88,12 @@ function App() {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [currentPage]);
+
+  useEffect(() => {
+    if (currentPage !== 'influxdb') {
+      setInfluxSubPage('summary');
+    }
   }, [currentPage]);
 
   // Real OPC data fetching with page-based optimization
@@ -354,7 +361,12 @@ function App() {
         );
 
       case 'influxdb':
-        return <InfluxDBMonitor />;
+        return (
+          <InfluxDBMonitor
+            activeTab={influxSubPage}
+            onTabChange={setInfluxSubPage}
+          />
+        );
 
 
       default:

--- a/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/ChartsTab.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/ChartsTab.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import type { InfluxMotorSeriesPoint, InfluxSystemTrendPoint } from '../../services/api';
+import MotorTimeSeriesChart from './MotorTimeSeriesChart';
+import SystemMetricsChart from './SystemMetricsChart';
+
+interface ChartsTabProps {
+  motors: Record<number, { status?: number } | undefined>;
+  selectedMotors: number[];
+  onMotorSelection: (motorId: number, selected: boolean) => void;
+  selectedMetrics: string[];
+  onMetricSelection: (metric: string, selected: boolean) => void;
+  motorTimeSeriesData: InfluxMotorSeriesPoint[];
+  systemTrendsData: InfluxSystemTrendPoint[];
+  timeRange: string;
+  onOpenMotorFullscreen: () => void;
+  onOpenSystemFullscreen: () => void;
+}
+
+const metricDefinitions = [
+  { key: 'pressure', label: 'Pressure (bar)', color: '#00ff88' },
+  { key: 'flow', label: 'Flow (L/min)', color: '#0099ff' },
+  { key: 'temperature', label: 'Temperature (°C)', color: '#ff6b35' },
+  { key: 'rpm', label: 'RPM', color: '#ffa500' },
+  { key: 'current', label: 'Current (A)', color: '#dda0dd' }
+];
+
+const ChartsTab: React.FC<ChartsTabProps> = ({
+  motors,
+  selectedMotors,
+  onMotorSelection,
+  selectedMetrics,
+  onMetricSelection,
+  motorTimeSeriesData,
+  systemTrendsData,
+  timeRange,
+  onOpenMotorFullscreen,
+  onOpenSystemFullscreen
+}) => {
+  return (
+    <div className="influx-charts-tab">
+      <div className="charts-tab-grid">
+        <div className="selection-panel">
+          <div className="motor-selector">
+            <h3 className="panel-title">Motor Selection</h3>
+            <div className="motor-checkboxes">
+              {[1, 2, 3, 4, 5, 6, 7].map(motorId => (
+                <label key={motorId} className="motor-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={selectedMotors.includes(motorId)}
+                    onChange={(e) => onMotorSelection(motorId, e.target.checked)}
+                    className="industrial-checkbox"
+                  />
+                  <span className="checkbox-label">Motor {motorId}</span>
+                  <span className={`status-dot status-${motors[motorId]?.status === 1 ? 'running' : 'ready'}`} />
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="metric-selector">
+            <h3 className="panel-title">Metrics</h3>
+            <div className="metric-checkboxes">
+              {metricDefinitions.map(metric => (
+                <label key={metric.key} className="metric-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={selectedMetrics.includes(metric.key)}
+                    onChange={(e) => onMetricSelection(metric.key, e.target.checked)}
+                    className="industrial-checkbox"
+                  />
+                  <span className="checkbox-label">{metric.label}</span>
+                  <span
+                    className="metric-color-indicator"
+                    style={{ backgroundColor: metric.color }}
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="charts-panel">
+          <div className="motor-charts-container">
+            <MotorTimeSeriesChart
+              data={motorTimeSeriesData}
+              selectedMotors={selectedMotors}
+              selectedMetrics={selectedMetrics}
+              timeRange={timeRange}
+              onOpenFullscreen={onOpenMotorFullscreen}
+            />
+          </div>
+          <div className="system-charts-container">
+            <SystemMetricsChart
+              data={systemTrendsData}
+              timeRange={timeRange}
+              onOpenFullscreen={onOpenSystemFullscreen}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChartsTab;

--- a/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/InfluxDBMonitor.css
+++ b/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/InfluxDBMonitor.css
@@ -5,7 +5,9 @@
   flex-direction: column;
   gap: var(--spacing-lg);
   padding: var(--spacing-lg);
-  min-height: 100vh;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
   background: var(--color-bg-primary);
   position: relative;
 }
@@ -160,6 +162,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
   background: rgba(22, 32, 38, 0.8);
   border: 1px solid rgba(96, 160, 255, 0.2);
   border-radius: var(--radius-md);
@@ -171,6 +175,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-lg);
+  flex-wrap: wrap;
 }
 
 .stat-item {
@@ -198,21 +203,6 @@
 .stat-separator {
   color: var(--color-border);
   font-size: 16px;
-}
-
-/* Main Content Grid */
-.influxdb-content-grid {
-  display: grid;
-  grid-template-columns: 1fr 350px;
-  gap: var(--spacing-lg);
-  flex: 1;
-}
-
-/* Charts Panel */
-.charts-panel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-lg);
 }
 
 .motor-selector,
@@ -289,35 +279,6 @@
   border-radius: 2px;
   margin-left: auto;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
-}
-
-/* Chart Containers */
-.motor-charts-container,
-.system-charts-container {
-  background: rgba(22, 32, 38, 0.9);
-  border: 1px solid rgba(96, 160, 255, 0.3);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  backdrop-filter: blur(12px);
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  position: relative;
-  overflow: hidden;
-}
-
-.motor-charts-container::before,
-.system-charts-container::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg,
-    transparent,
-    rgba(0, 255, 136, 0.4),
-    transparent);
 }
 
 /* Controls Panel */
@@ -419,26 +380,281 @@
   border: 1px solid var(--color-disabled);
 }
 
+/* Tabbed Layout */
+.influxdb-tab-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  flex: 1;
+  min-height: 0;
+}
+
+.influxdb-tab-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  background: rgba(15, 20, 25, 0.75);
+  border: 1px solid rgba(96, 160, 255, 0.2);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  backdrop-filter: blur(6px);
+}
+
+.influxdb-tab-button {
+  flex: 1 1 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  text-align: left;
+}
+
+.influxdb-tab-button:hover {
+  border-color: rgba(0, 153, 255, 0.5);
+  color: var(--color-text-primary);
+}
+
+.influxdb-tab-button.active {
+  background: rgba(0, 153, 255, 0.15);
+  border-color: rgba(0, 153, 255, 0.6);
+  color: var(--color-text-primary);
+  box-shadow: inset 0 0 0 1px rgba(0, 153, 255, 0.4);
+}
+
+.influxdb-tab-button .tab-label {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.influxdb-tab-button .tab-description {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  opacity: 0.9;
+}
+
+.influxdb-tab-button.active .tab-description {
+  color: rgba(0, 200, 255, 0.8);
+}
+
+.influxdb-tab-content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+/* Summary Tab */
+.influx-summary-tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.summary-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.summary-card {
+  background: rgba(15, 20, 25, 0.7);
+  border: 1px solid rgba(96, 160, 255, 0.2);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.summary-card.status-connected {
+  border-color: rgba(0, 255, 136, 0.5);
+  box-shadow: 0 0 24px rgba(0, 255, 136, 0.15);
+}
+
+.summary-card.status-connecting {
+  border-color: rgba(255, 200, 0, 0.4);
+}
+
+.summary-card.status-disconnected,
+.summary-card.status-error {
+  border-color: rgba(255, 107, 53, 0.4);
+}
+
+.summary-label {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.summary-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+
+.summary-subtext {
+  font-size: 11px;
+  color: var(--color-text-dim);
+}
+
+.summary-charts-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.summary-chart-card {
+  background: rgba(15, 20, 25, 0.55);
+  border: 1px solid rgba(96, 160, 255, 0.15);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+}
+
+.summary-bottom-grid {
+  display: grid;
+  gap: var(--spacing-lg);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+/* Charts Tab */
+.influx-charts-tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.charts-tab-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: var(--spacing-lg);
+  min-height: 0;
+}
+
+.selection-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.charts-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  min-height: 0;
+}
+
+.charts-panel > div {
+  background: rgba(15, 20, 25, 0.55);
+  border: 1px solid rgba(96, 160, 255, 0.2);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+}
+
+.motor-charts-container,
+.system-charts-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+/* Queries Tab */
+.influx-queries-tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.queries-tab-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: var(--spacing-lg);
+}
+
+/* Fullscreen Modal */
+.chart-fullscreen-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-fullscreen-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 6, 8, 0.82);
+  backdrop-filter: blur(6px);
+}
+
+.chart-fullscreen-content {
+  position: relative;
+  width: min(1200px, 95vw);
+  height: min(90vh, 720px);
+  background: rgba(12, 16, 20, 0.95);
+  border: 1px solid rgba(96, 160, 255, 0.4);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+
+.chart-fullscreen-close {
+  position: absolute;
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  color: var(--color-text-primary);
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.chart-fullscreen-close:hover {
+  background: rgba(0, 153, 255, 0.25);
+  border-color: rgba(0, 153, 255, 0.6);
+}
+
 /* Responsive Design */
 @media (max-width: 1400px) {
-  .influxdb-content-grid {
-    grid-template-columns: 1fr 300px;
+  .charts-tab-grid {
+    grid-template-columns: minmax(240px, 300px) 1fr;
   }
 
-  .motor-checkboxes,
-  .metric-checkboxes {
-    gap: var(--spacing-md);
+  .queries-tab-grid {
+    grid-template-columns: 1.5fr 1fr;
   }
 }
 
 @media (max-width: 1200px) {
-  .influxdb-content-grid {
+  .charts-tab-grid,
+  .queries-tab-grid {
     grid-template-columns: 1fr;
-    gap: var(--spacing-md);
   }
 
-  .controls-panel {
-    order: -1;
+  .selection-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
   }
 
   .header-controls {
@@ -459,9 +675,23 @@
     align-items: flex-start;
   }
 
+  .influxdb-tab-controls {
+    flex-direction: column;
+  }
+
+  .influxdb-tab-button {
+    width: 100%;
+  }
+
   .header-controls {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .summary-overview-grid,
+  .summary-charts-row,
+  .summary-bottom-grid {
+    grid-template-columns: 1fr;
   }
 
   .motor-checkboxes,
@@ -510,8 +740,9 @@
   .influxdb-header,
   .motor-selector,
   .metric-selector,
-  .motor-charts-container,
-  .system-charts-container,
+  .summary-card,
+  .summary-chart-card,
+  .charts-panel > div,
   .performance-metrics,
   .alert-config {
     background: rgba(0, 0, 0, 0.9);

--- a/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/QueriesTab.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/QueriesTab.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import DataExportPanel from './DataExportPanel';
+import QueryManagementPanel, { QueryHistoryItem } from './QueryManagementPanel';
+
+interface QueriesTabProps {
+  queryHistory: QueryHistoryItem[];
+  onExecuteQuery: (query: string) => void;
+  selectedMotors: number[];
+  selectedMetrics: string[];
+  timeRange: string;
+  dataCount: number;
+}
+
+const QueriesTab: React.FC<QueriesTabProps> = ({
+  queryHistory,
+  onExecuteQuery,
+  selectedMotors,
+  selectedMetrics,
+  timeRange,
+  dataCount
+}) => {
+  return (
+    <div className="influx-queries-tab">
+      <div className="queries-tab-grid">
+        <QueryManagementPanel queryHistory={queryHistory} onExecuteQuery={onExecuteQuery} />
+        <DataExportPanel
+          selectedMotors={selectedMotors}
+          selectedMetrics={selectedMetrics}
+          timeRange={timeRange}
+          dataCount={dataCount}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default QueriesTab;

--- a/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/QueryManagementPanel.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/QueryManagementPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-interface QueryHistoryItem {
+export interface QueryHistoryItem {
   id: number;
   query: string;
   timestamp: Date;

--- a/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/SummaryTab.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/InfluxDBMonitor/SummaryTab.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import type { InfluxMotorSeriesPoint, InfluxSystemTrendPoint } from '../../services/api';
+import type { ConnectionStatus } from './InfluxDBConnectionPanel';
+import MotorTimeSeriesChart from './MotorTimeSeriesChart';
+import SystemMetricsChart from './SystemMetricsChart';
+
+interface SummaryTabProps {
+  connectionStatus: ConnectionStatus;
+  lastUpdate: Date | null;
+  motorTimeSeriesData: InfluxMotorSeriesPoint[];
+  systemTrendsData: InfluxSystemTrendPoint[];
+  selectedMotors: number[];
+  selectedMetrics: string[];
+  timeRange: string;
+}
+
+const SummaryTab: React.FC<SummaryTabProps> = ({
+  connectionStatus,
+  lastUpdate,
+  motorTimeSeriesData,
+  systemTrendsData,
+  selectedMotors,
+  selectedMetrics,
+  timeRange
+}) => {
+  const statusLabel = connectionStatus.status.toUpperCase();
+  const lastQueryText = connectionStatus.lastQuery.toLocaleTimeString('tr-TR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+  const opcLastUpdate = lastUpdate
+    ? lastUpdate.toLocaleTimeString('tr-TR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : 'Not available';
+
+  return (
+    <div className="influx-summary-tab">
+      <div className="summary-overview-grid">
+        <div className={`summary-card status-${connectionStatus.status}`}>
+          <span className="summary-label">Connection</span>
+          <span className="summary-value">{statusLabel}</span>
+          <span className="summary-subtext">Last query {lastQueryText}</span>
+        </div>
+        <div className="summary-card">
+          <span className="summary-label">Data Points</span>
+          <span className="summary-value">{connectionStatus.recordCount.toLocaleString()}</span>
+          <span className="summary-subtext">Range {timeRange}</span>
+        </div>
+        <div className="summary-card">
+          <span className="summary-label">Selected Motors</span>
+          <span className="summary-value">{selectedMotors.length}</span>
+          <span className="summary-subtext">{selectedMotors.length > 0 ? selectedMotors.join(', ') : 'None'}</span>
+        </div>
+        <div className="summary-card">
+          <span className="summary-label">Active Metrics</span>
+          <span className="summary-value">{selectedMetrics.length}</span>
+          <span className="summary-subtext">{selectedMetrics.join(', ') || 'None'}</span>
+        </div>
+        <div className="summary-card">
+          <span className="summary-label">OPC Snapshot</span>
+          <span className="summary-value">{opcLastUpdate}</span>
+          <span className="summary-subtext">Last OPC refresh</span>
+        </div>
+        <div className="summary-card">
+          <span className="summary-label">Data Rate</span>
+          <span className="summary-value">{connectionStatus.dataRate}</span>
+          <span className="summary-subtext">Streaming estimate</span>
+        </div>
+      </div>
+
+      <div className="summary-charts-row">
+        <div className="summary-chart-card">
+          <MotorTimeSeriesChart
+            data={motorTimeSeriesData}
+            selectedMotors={selectedMotors}
+            selectedMetrics={selectedMetrics}
+            timeRange={timeRange}
+            variant="compact"
+          />
+        </div>
+        <div className="summary-chart-card">
+          <SystemMetricsChart
+            data={systemTrendsData}
+            timeRange={timeRange}
+            variant="compact"
+          />
+        </div>
+      </div>
+
+      <div className="summary-bottom-grid">
+        <div className="performance-metrics">
+          <h3 className="panel-title">Database Performance</h3>
+          <div className="performance-grid">
+            <div className="perf-metric">
+              <span className="perf-label">Query Rate</span>
+              <span className="perf-value">15.2/min</span>
+            </div>
+            <div className="perf-metric">
+              <span className="perf-label">Avg Response</span>
+              <span className="perf-value">0.45s</span>
+            </div>
+            <div className="perf-metric">
+              <span className="perf-label">Storage Used</span>
+              <span className="perf-value">2.4 GB</span>
+            </div>
+            <div className="perf-metric">
+              <span className="perf-label">Data Points/hr</span>
+              <span className="perf-value">48.6k</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="alert-config">
+          <h3 className="panel-title">Alert Configuration</h3>
+          <div className="alert-items">
+            <div className="alert-item">
+              <span className="alert-name">High Pressure</span>
+              <span className="alert-threshold">&gt; 300 bar</span>
+              <span className="alert-status alert-active">Active</span>
+            </div>
+            <div className="alert-item">
+              <span className="alert-name">Low Flow Rate</span>
+              <span className="alert-threshold">&lt; 10 L/min</span>
+              <span className="alert-status alert-active">Active</span>
+            </div>
+            <div className="alert-item">
+              <span className="alert-name">High Temperature</span>
+              <span className="alert-threshold">&gt; 80°C</span>
+              <span className="alert-status alert-inactive">Inactive</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SummaryTab;


### PR DESCRIPTION
## Summary
- split the InfluxDB monitor into Summary, Charts, and Queries tabs with dedicated subcomponents and modal fullscreen chart support
- extend the motor and system chart components to support compact and fullscreen variants used by the new layout
- wire the application to track Influx sub-page state and refresh the monitor styles for the tabbed experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db12cd17f88322b01be9c03384da27