### PR TITLE
feat: add motor group tabs layout

### DIFF
--- a/tusas-hgu-modern/Frontend/src/App.tsx
+++ b/tusas-hgu-modern/Frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useOpcStore } from './store/opcStore';
 import { useAuth } from './contexts/AuthContext';
 import { opcApiService } from './services/opcApiService';
 import { useSystemModeTransition } from './hooks/useSystemModeTransition';
 import HamburgerMenu from './components/HamburgerMenu';
-import CompactMotorPanel from './components/CompactMotorPanel';
+import MotorGroupView from './components/CompactMotorPanel/MotorGroupView';
 import MotorDetailModal from './components/MotorDetailModal';
 import SystemOverviewPanel from './components/SystemOverviewPanel';
 import TankCoolingPanel from './components/TankCoolingPanel';
@@ -14,12 +14,36 @@ import InfluxDBMonitor from './components/InfluxDBMonitor';
 import './styles/industrial-theme.css';
 import './styles/modern-layout.css';
 
+const MOTOR_GROUPS = [
+  {
+    id: 'main',
+    label: 'Ana Pompalar',
+    description: 'Ana hat debi kontrolü',
+    motorIds: [1, 2, 3, 4]
+  },
+  {
+    id: 'support',
+    label: 'Destek Pompaları',
+    description: 'Hazırlık ve bakım desteği',
+    motorIds: [5, 6]
+  },
+  {
+    id: 'pressure',
+    label: 'Yüksek Basınç',
+    description: 'Sızdırmazlık devresi',
+    motorIds: [7]
+  }
+] as const;
+
+type MotorGroupId = typeof MOTOR_GROUPS[number]['id'];
+
 function App() {
   const { token } = useAuth();
-  const { 
-    system, 
-    isConnected, 
-    isLoading, 
+  const {
+    system,
+    motors,
+    isConnected,
+    isLoading,
     errors,
     currentPage: storeCurrentPage,
     fetchPageData, 
@@ -33,6 +57,7 @@ function App() {
   const [selectedMotorId, setSelectedMotorId] = useState<number | null>(null);
   const [selectedSystemPanel, setSelectedSystemPanel] = useState<string | null>(null);
   const [alarms, setAlarms] = useState<Array<{ id: number; message: string; type: string }>>([]);
+  const [motorSubPage, setMotorSubPage] = useState<MotorGroupId>(MOTOR_GROUPS[0].id);
   
   // Use system mode transition hook
   const transitionState = useSystemModeTransition();
@@ -42,6 +67,48 @@ function App() {
   
   // Use store's currentPage directly
   const currentPage = storeCurrentPage as 'main' | 'motors' | 'logs' | 'alarms' | 'stats' | 'influxdb';
+
+  const activeMotorGroup = useMemo(() => {
+    return MOTOR_GROUPS.find(group => group.id === motorSubPage) ?? MOTOR_GROUPS[0];
+  }, [motorSubPage]);
+
+  const selectedGroupMotors = useMemo(() => {
+    return activeMotorGroup.motorIds.map(id => motors[id]);
+  }, [activeMotorGroup, motors]);
+
+  const groupActiveCount = useMemo(() => {
+    return selectedGroupMotors.reduce((count, motor) => count + (motor.status === 1 ? 1 : 0), 0);
+  }, [selectedGroupMotors]);
+
+  const groupAveragePressure = useMemo(() => {
+    if (!selectedGroupMotors.length) return null;
+    const total = selectedGroupMotors.reduce((sum, motor) => sum + (Number.isFinite(motor.pressure) ? motor.pressure : 0), 0);
+    return selectedGroupMotors.length ? total / selectedGroupMotors.length : null;
+  }, [selectedGroupMotors]);
+
+  const groupAverageFlow = useMemo(() => {
+    if (!selectedGroupMotors.length) return null;
+    const total = selectedGroupMotors.reduce((sum, motor) => sum + (Number.isFinite(motor.flow) ? motor.flow : 0), 0);
+    return selectedGroupMotors.length ? total / selectedGroupMotors.length : null;
+  }, [selectedGroupMotors]);
+
+  const systemFlowMetrics = useMemo(() => ([
+    {
+      key: 'totalFlow',
+      label: 'Toplam Debi',
+      value: system?.totalFlow ? `${system.totalFlow.toFixed(1)} L/dk` : 'ERR'
+    },
+    {
+      key: 'totalPressure',
+      label: 'Toplam Basınç',
+      value: system?.totalPressure ? `${system.totalPressure.toFixed(1)} bar` : 'ERR'
+    },
+    {
+      key: 'activePumps',
+      label: 'Aktif Motor',
+      value: system?.activePumps !== undefined ? system.activePumps : 'ERR'
+    }
+  ]), [system.totalFlow, system.totalPressure, system.activePumps]);
 
   // Set auth token when it changes
   useEffect(() => {
@@ -270,49 +337,62 @@ function App() {
       case 'motors':
         return (
           <div className="motors-page-content">
-            {/* Motor Grid - 4 üstte, 3 altta */}
-            <div className="ultra-compact-motor-grid">
-              {/* Top row - Motors 1,2,3,4 */}
-              <div className="motor-row-top">
-                {[1, 2, 3, 4].map(id => (
-                  <div key={id} className="ultra-compact-motor-wrapper">
-                    <CompactMotorPanel 
-                      motorId={id} 
-                      onClick={() => handleMotorClick(id)}
-                    />
+            <div className="motor-page-shell">
+              <section className="motor-groups-section">
+                <div className="motor-group-tabs" role="tablist" aria-label="Motor Grupları">
+                  {MOTOR_GROUPS.map(group => {
+                    const isActive = group.id === motorSubPage;
+                    return (
+                      <button
+                        key={group.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        className={`motor-group-tab ${isActive ? 'active' : ''}`}
+                        onClick={() => setMotorSubPage(group.id)}
+                      >
+                        <span className="motor-group-label">{group.label}</span>
+                        <span className="motor-count-badge">{group.motorIds.length}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="motor-group-description">{activeMotorGroup.description}</p>
+                <MotorGroupView
+                  key={activeMotorGroup.id}
+                  motorIds={activeMotorGroup.motorIds}
+                  onMotorSelect={handleMotorClick}
+                />
+              </section>
+              <aside className="motor-summary-card">
+                <div className="motor-summary-header">
+                  <span className="motor-summary-title">Grup Özeti</span>
+                  <h2 className="motor-summary-group">{activeMotorGroup.label}</h2>
+                  <span className="motor-summary-subtitle">{activeMotorGroup.description}</span>
+                </div>
+                <div className="motor-summary-metrics">
+                  <div className="motor-summary-metric">
+                    <span className="motor-summary-label">Aktif Motor</span>
+                    <span className="motor-summary-value">{groupActiveCount} / {activeMotorGroup.motorIds.length}</span>
                   </div>
-                ))}
-              </div>
-              
-              {/* Bottom row - Motors 5,6,7 */}
-              <div className="motor-row-bottom">
-                {[5, 6, 7].map(id => (
-                  <div key={id} className="ultra-compact-motor-wrapper">
-                    <CompactMotorPanel 
-                      motorId={id} 
-                      onClick={() => handleMotorClick(id)}
-                    />
+                  <div className="motor-summary-metric">
+                    <span className="motor-summary-label">Ortalama Basınç</span>
+                    <span className="motor-summary-value">{groupAveragePressure !== null ? `${groupAveragePressure.toFixed(1)} bar` : '---'}</span>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            {/* System Flow Summary */}
-            <div className="system-flow-summary">
-              <div className="flow-metric">
-                <span className="flow-label">Total Flow:</span>
-                <span className="flow-value">{system?.totalFlow ? `${system.totalFlow.toFixed(1)} L/min` : 'ERR'}</span>
-              </div>
-              <div className="flow-separator">|</div>
-              <div className="flow-metric">
-                <span className="flow-label">Total Pressure:</span>
-                <span className="flow-value">{system?.totalPressure ? `${system.totalPressure.toFixed(1)} bar` : 'ERR'}</span>
-              </div>
-              <div className="flow-separator">|</div>
-              <div className="flow-metric">
-                <span className="flow-label">Active Motors:</span>
-                <span className="flow-value">{system?.activePumps !== undefined ? system.activePumps : 'ERR'}</span>
-              </div>
+                  <div className="motor-summary-metric">
+                    <span className="motor-summary-label">Ortalama Debi</span>
+                    <span className="motor-summary-value">{groupAverageFlow !== null ? `${groupAverageFlow.toFixed(1)} L/dk` : '---'}</span>
+                  </div>
+                </div>
+                <div className="system-flow-summary">
+                  {systemFlowMetrics.map(metric => (
+                    <div key={metric.key} className="flow-metric">
+                      <span className="flow-label">{metric.label}</span>
+                      <span className="flow-value">{metric.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </aside>
             </div>
           </div>
         );

--- a/tusas-hgu-modern/Frontend/src/components/CompactMotorPanel/MotorGroupView.tsx
+++ b/tusas-hgu-modern/Frontend/src/components/CompactMotorPanel/MotorGroupView.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react';
+import CompactMotorPanel from '.';
+
+interface MotorGroupViewProps {
+  motorIds: ReadonlyArray<number>;
+  onMotorSelect?: (motorId: number) => void;
+}
+
+const DEFAULT_SLOT_COUNT = 4;
+
+const MotorGroupView: React.FC<MotorGroupViewProps> = ({ motorIds, onMotorSelect }) => {
+  const paddedMotorIds = useMemo(() => {
+    const slotCount = Math.max(DEFAULT_SLOT_COUNT, motorIds.length);
+    const slots: Array<number | null> = [...motorIds];
+
+    while (slots.length < slotCount) {
+      slots.push(null);
+    }
+
+    return slots;
+  }, [motorIds]);
+
+  return (
+    <div className="motor-group-view">
+      <div className="ultra-compact-motor-grid">
+        {paddedMotorIds.map((id, index) => (
+          id !== null ? (
+            <div key={id} className="ultra-compact-motor-wrapper">
+              <CompactMotorPanel
+                motorId={id}
+                onClick={() => onMotorSelect?.(id)}
+              />
+            </div>
+          ) : (
+            <div key={`placeholder-${index}`} className="motor-card-placeholder" aria-hidden="true" />
+          )
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MotorGroupView;

--- a/tusas-hgu-modern/Frontend/src/styles/modern-layout.css
+++ b/tusas-hgu-modern/Frontend/src/styles/modern-layout.css
@@ -710,81 +710,82 @@
   font-style: italic;
 }
 
-/* Motors Page Responsive for different screen heights */
-@media (max-height: 768px) {
-  .ultra-compact-motor-grid {
-    grid-template-rows: repeat(2, minmax(100px, 1fr));
-    max-height: calc(100vh - 240px);
-  }
-  
+/* Motors Page Responsive adjustments */
+@media (max-height: 820px) {
   .motors-page-content {
-    height: calc(100vh - 140px);
+    height: calc(100vh - 135px);
+    max-height: calc(100vh - 135px);
+    padding: 1rem 1.25rem;
   }
-}
 
-@media (min-height: 900px) {
+  .motor-page-shell {
+    gap: 1.1rem;
+  }
+
+  .motor-groups-section,
+  .motor-summary-card {
+    padding: 1rem 1.1rem;
+    border-radius: 14px;
+  }
+
   .ultra-compact-motor-grid {
-    grid-template-rows: repeat(2, minmax(200px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .motor-summary-value {
+    font-size: 1.25rem;
   }
 }
 
-/* Wide screens - show all 7 motors optimally */
+@media (max-width: 1280px) {
+  .motor-page-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+  }
+
+  .motors-page-content {
+    height: auto;
+    max-height: none;
+    overflow-y: auto;
+  }
+
+  .motor-summary-card {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .motors-page-content {
+    padding: 1rem;
+  }
+
+  .motor-groups-section,
+  .motor-summary-card {
+    padding: 0.9rem;
+  }
+
+  .motor-group-tabs {
+    gap: 0.5rem;
+  }
+
+  .motor-group-tab {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .motor-summary-value {
+    font-size: 1.15rem;
+  }
+}
+
 @media (min-width: 1600px) {
+  .motor-page-shell {
+    max-width: 1650px;
+    gap: 1.75rem;
+  }
+
   .ultra-compact-motor-grid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: 1.5rem;
-    margin: 1.5rem;
+    gap: 1.25rem;
   }
-}
-
-@media (min-width: 1920px) {
-  .ultra-compact-motor-grid {
-    grid-template-columns: repeat(4, minmax(300px, 1fr));
-    gap: 2rem;
-    margin: 2rem;
-  }
-}
-
-@media (max-width: 900px) {
-  .motor-row-top {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  
-  .motor-row-bottom {
-    width: 100%;
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-/* Special Motor 7 Layout - High Pressure System */
-.motor-row-special {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 30px;
-  padding: 20px;
-  border-top: 1px solid rgba(245, 158, 11, 0.2);
-}
-
-.special-motor {
-  position: relative;
-}
-
-.special-motor::before {
-  content: 'HIGH PRESSURE SYSTEM';
-  position: absolute;
-  top: -25px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 11px;
-  font-weight: 600;
-  color: rgba(245, 158, 11, 0.9);
-  background: rgba(245, 158, 11, 0.1);
-  padding: 4px 12px;
-  border-radius: 20px;
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  white-space: nowrap;
-  z-index: 10;
 }
 
 /* Responsive Design */
@@ -1047,16 +1048,182 @@
   to { transform: rotate(360deg); }
 }
 
-/* Motors Page Styles - RESPONSIVE SCROLLING */
+/* Motors Page Shell - Scroll-free layout */
 .motors-page-content {
-  min-height: calc(100vh - 180px); /* Minimum viewport minus header */
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 1.5rem 1.5rem;
+  box-sizing: border-box;
+  height: calc(100vh - 150px);
+  max-height: calc(100vh - 150px);
+  overflow: hidden;
+}
+
+.motor-page-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 1480px;
+  height: 100%;
+  min-height: 0;
+}
+
+.motor-groups-section {
   display: flex;
   flex-direction: column;
-  padding: 1rem;
-  overflow-x: hidden; /* Prevent horizontal overflow */
-  overflow-y: auto; /* Enable vertical scrolling when needed */
-  max-width: 100%; /* Prevent overflow */
-  box-sizing: border-box;
+  gap: 1rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(15, 23, 42, 0.55));
+  border: 1px solid rgba(96, 160, 255, 0.25);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow:
+    0 8px 24px rgba(2, 6, 23, 0.45),
+    inset 0 1px 0 rgba(148, 163, 184, 0.08);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.motor-group-tabs {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.motor-group-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 160, 255, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: #cbd5f5;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.motor-group-tab:hover,
+.motor-group-tab:focus-visible {
+  border-color: rgba(96, 160, 255, 0.6);
+  color: #e0e7ff;
+  box-shadow: 0 6px 18px rgba(14, 116, 233, 0.25);
+  outline: none;
+}
+
+.motor-group-tab.active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(37, 99, 235, 0.55));
+  border-color: rgba(96, 160, 255, 0.9);
+  color: #ffffff;
+  box-shadow:
+    0 10px 28px rgba(30, 64, 175, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.motor-group-label {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.motor-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.motor-group-description {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.85);
+  font-size: 0.85rem;
+  letter-spacing: 0.2px;
+}
+
+.motor-group-view {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.motor-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.78));
+  border: 1px solid rgba(96, 160, 255, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow:
+    0 10px 28px rgba(2, 6, 23, 0.5),
+    inset 0 1px 0 rgba(148, 163, 184, 0.08);
+  min-height: 0;
+}
+
+.motor-summary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.motor-summary-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.45em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.motor-summary-group {
+  margin: 0;
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: #e2e8f0;
+  letter-spacing: 0.04em;
+}
+
+.motor-summary-subtitle {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.motor-summary-metrics {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.9rem;
+}
+
+.motor-summary-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(96, 160, 255, 0.25);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.05);
+}
+
+.motor-summary-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.75);
+  letter-spacing: 0.05em;
+}
+
+.motor-summary-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #38bdf8;
+  font-family: 'Consolas', 'SFMono-Regular', monospace;
 }
 
 .motors-page-header {
@@ -1108,163 +1275,71 @@
   animation: pulse 2s ease-in-out infinite;
 }
 
-/* Ultra Compact Motor Grid - FULL SCREEN LAYOUT */
+/* Ultra compact motor grid for group view */
 .ultra-compact-motor-grid {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin: 1rem;
-  min-height: 400px; /* Minimum height instead of fixed height */
-  width: calc(100% - 2rem); /* Changed from 100vw to 100% to respect parent container */
-  padding: 0;
-  box-sizing: border-box; /* Include padding and border in width calculation */
-}
-
-/* Top row - 4 motors */
-.motor-row-top {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
   gap: 1rem;
-  flex: 1;
-}
-
-/* Bottom row - 3 motors centered (inverted pyramid) */
-.motor-row-bottom {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  flex: 1;
-  width: 75%; /* 3/4 of the width since we have 3 motors instead of 4 */
-  margin: 0 auto; /* Center the entire row */
+  width: 100%;
+  min-height: 0;
 }
 
 .ultra-compact-motor-wrapper {
   display: flex;
-  justify-content: center;
+  min-height: 0;
 }
 
-.motor-7-ultra-compact {
-  /* Normal size like other motors */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-/* Override CompactMotorPanel for ultra-compact view - RESPONSIVE SIZING */
 .ultra-compact-motor-grid .enhanced-motor-panel {
   width: 100% !important;
   height: 100% !important;
   max-width: none !important;
-  min-height: unset !important;
-  padding: 0.75rem !important;
-  font-size: 12px !important;
+  padding: 0.9rem !important;
   display: flex !important;
   flex-direction: column !important;
   justify-content: space-between !important;
 }
 
-.ultra-compact-motor-grid .compact-header {
-  margin-bottom: 4px !important;
+.motor-card-placeholder {
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.08);
 }
 
-.ultra-compact-motor-grid .motor-id {
-  font-size: 16px !important;
-  font-weight: 700 !important;
-}
-
-.ultra-compact-motor-grid .special-badge {
-  font-size: 8px !important;
-  padding: 1px 4px !important;
-}
-
-.ultra-compact-motor-grid .primary-metrics {
-  gap: 8px !important;
-  margin: 6px 0 !important;
-}
-
-.ultra-compact-motor-grid .metric-value {
-  font-size: 16px !important;
-  font-weight: 600 !important;
-}
-
-.ultra-compact-motor-grid .metric-unit {
-  font-size: 10px !important;
-}
-
-.ultra-compact-motor-grid .secondary-info {
-  gap: 2px !important;
-  margin: 4px 0 !important;
-}
-
-.ultra-compact-motor-grid .info-row {
-  font-size: 9px !important;
-}
-
-.ultra-compact-motor-grid .quick-indicators {
-  gap: 6px !important;
-  margin-top: 4px !important;
-}
-
-.ultra-compact-motor-grid .indicator {
-  font-size: 10px !important;
-}
-
-.ultra-compact-motor-grid .expand-hint {
-  font-size: 8px !important;
-  margin-top: 2px !important;
-}
-
-.ultra-compact-motor-grid .expand-icon {
-  font-size: 10px !important;
-}
-
-/* Motor 7 special ultra-compact styling - MAIN PUMP */
-.motor-7-ultra-compact .compact-motor-panel {
-  width: 100% !important;
-  max-width: 500px !important;
-  min-width: 400px !important;
-  height: 100% !important;
-  min-height: 140px !important;
-  max-height: 200px !important;
-}
-
-/* System Flow Summary - COMPACT */
+/* System Flow Summary - aligned with summary card */
 .system-flow-summary {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(71, 85, 105, 0.3);
-  border-radius: 8px;
-  margin-top: 0.5rem;
-  flex-shrink: 0; /* Don't shrink */
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem 1.1rem;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(96, 160, 255, 0.25);
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgba(30, 64, 175, 0.1);
 }
 
 .flow-metric {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
 }
 
 .flow-label {
-  color: #94a3b8;
-  font-size: 14px;
-  font-weight: 500;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .flow-value {
-  color: #22c55e;
-  font-size: 18px;
+  color: #4ade80;
+  font-size: 1.4rem;
   font-weight: 700;
-}
-
-.flow-separator {
-  color: rgba(148, 163, 184, 0.5);
-  font-size: 20px;
-  font-weight: 300;
+  font-family: 'Consolas', 'SFMono-Regular', monospace;
 }
 
 /* Stats Page Styles */


### PR DESCRIPTION
## Summary
- add group-based tabs to the motors page and surface live metrics for the selected cluster
- introduce a dedicated MotorGroupView component that arranges motor cards in a fixed 2x2 grid
- refresh the modern layout styles to align the summary card with the grid and avoid vertical scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db12b88cf88322a120c45a5d990cc3